### PR TITLE
Fixes for issues 12, 13, 14

### DIFF
--- a/hatch_containers/dockerfile.py
+++ b/hatch_containers/dockerfile.py
@@ -3,26 +3,42 @@
 # SPDX-License-Identifier: MIT
 LINUX_TEMPLATE_ENVIRONMENT = """\
 FROM {base_image}
+ARG USER_UID
+ARG USER_GID
 
-RUN python -m pip install --disable-pip-version-check --upgrade virtualenv hatchling \
- && python -m virtualenv /home/venv --no-download --no-periodic-update --pip embed
+RUN set -eux; \
+    addgroup --gid $USER_GID user; \
+    adduser --disabled-password --gecos "" --home /home/user --ingroup user --uid "$USER_UID" user
 
-ENV VIRTUAL_ENV="/home/venv" PATH="/home/venv/bin:$PATH"
+USER $USER_UID:$USER_GID
+RUN set -eux; \
+    python -m pip install --disable-pip-version-check --upgrade virtualenv hatchling; \
+    python -m virtualenv /home/user/venv --no-download --no-periodic-update --pip embed
+
+ENV VIRTUAL_ENV="/home/user/venv" PATH="/home/user/venv/bin:$PATH"
 
 WORKDIR /home/project
 """
 
 LINUX_TEMPLATE_BUILDER = """\
 FROM {base_image}
+ARG USER_UID
+ARG USER_GID
 
-RUN python -m pip install --disable-pip-version-check --upgrade virtualenv \
- && python -m virtualenv /home/venv --no-download --no-periodic-update --pip embed
+RUN set -eux; \
+    addgroup --gid $USER_GID user; \
+    adduser --disabled-password --gecos "" --home /home/user --ingroup user --uid "$USER_UID" user
 
-ENV VIRTUAL_ENV="/home/venv" PATH="/home/venv/bin:$PATH"
+USER $USER_UID:$USER_GID
+RUN set -eux; \
+    python -m pip install --disable-pip-version-check --upgrade virtualenv hatchling; \
+    python -m virtualenv /home/user/venv --no-download --no-periodic-update --pip embed
+
+ENV VIRTUAL_ENV="/home/user/venv" PATH="/home/user/venv/bin:$PATH"
 
 WORKDIR /home/project
 
-COPY . /home/project
+COPY --chown=$USER_UID:$USER_GID . /home/project
 """
 
 

--- a/hatch_containers/dockerfile.py
+++ b/hatch_containers/dockerfile.py
@@ -12,7 +12,8 @@ RUN set -eux; \
     fi; \
     if ! getent passwd $USER_UID >/dev/null 2>&1; then \
         adduser --disabled-password --gecos "" --home /home/user --ingroup user --uid "$USER_UID" user; \
-    fi
+    fi; \
+    install -d -o $USER_UID -g $USER_GID -m 0755 /home/project
 
 USER $USER_UID:$USER_GID
 RUN set -eux; \
@@ -35,7 +36,8 @@ RUN set -eux; \
     fi; \
     if ! getent passwd $USER_UID >/dev/null 2>&1; then \
         adduser --disabled-password --gecos "" --home /home/user --ingroup user --uid "$USER_UID" user; \
-    fi
+    fi; \
+    install -d -o $USER_UID -g $USER_GID -m 0755 /home/project
 
 USER $USER_UID:$USER_GID
 RUN set -eux; \

--- a/hatch_containers/dockerfile.py
+++ b/hatch_containers/dockerfile.py
@@ -7,8 +7,12 @@ ARG USER_UID
 ARG USER_GID
 
 RUN set -eux; \
-    addgroup --gid $USER_GID user; \
-    adduser --disabled-password --gecos "" --home /home/user --ingroup user --uid "$USER_UID" user
+    if ! getent group $USER_GID >/dev/null 2>&1; then \
+        addgroup --gid $USER_GID user; \
+    fi; \
+    if ! getent passwd $USER_UID >/dev/null 2>&1; then \
+        adduser --disabled-password --gecos "" --home /home/user --ingroup user --uid "$USER_UID" user; \
+    fi
 
 USER $USER_UID:$USER_GID
 RUN set -eux; \
@@ -26,8 +30,12 @@ ARG USER_UID
 ARG USER_GID
 
 RUN set -eux; \
-    addgroup --gid $USER_GID user; \
-    adduser --disabled-password --gecos "" --home /home/user --ingroup user --uid "$USER_UID" user
+    if ! getent group $USER_GID >/dev/null 2>&1; then \
+        addgroup --gid $USER_GID user; \
+    fi; \
+    if ! getent passwd $USER_UID >/dev/null 2>&1; then \
+        adduser --disabled-password --gecos "" --home /home/user --ingroup user --uid "$USER_UID" user; \
+    fi
 
 USER $USER_UID:$USER_GID
 RUN set -eux; \

--- a/hatch_containers/plugin.py
+++ b/hatch_containers/plugin.py
@@ -154,6 +154,7 @@ class ContainerEnvironment(EnvironmentInterface):
             '--name', self.container_name,
             '--workdir', self.project_path,
             '--volume', f'{self.root}:{self.project_path}',
+            '--user', f'{self.uid}:{self.gid}',
         ]
         # fmt: on
 
@@ -246,6 +247,7 @@ class ContainerEnvironment(EnvironmentInterface):
                 'docker', 'create',
                 '--name', self.builder_container_name,
                 '--workdir', self.project_path,
+                '--user', f'{self.uid}:{self.gid}',
             ]
             # fmt: on
 
@@ -294,7 +296,7 @@ class ContainerEnvironment(EnvironmentInterface):
             return dict(self.env_vars)
 
     def construct_container_command(self, args, *, interactive=False):
-        command = ['docker', 'exec']
+        command = ['docker', 'exec', '--user', f'{self.uid}:{self.gid}']
         if interactive:  # no cov
             command.append('-it')
 
@@ -304,7 +306,7 @@ class ContainerEnvironment(EnvironmentInterface):
         return command
 
     def construct_builder_command(self, args):
-        command = ['docker', 'exec']
+        command = ['docker', 'exec', '--user', f'{self.uid}:{self.gid}']
 
         self.apply_env_vars(command)
         command.append(self.builder_container_name)

--- a/hatch_containers/plugin.py
+++ b/hatch_containers/plugin.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import os
 import re
+import shutil
 import sys
 from contextlib import contextmanager
 

--- a/hatch_containers/plugin.py
+++ b/hatch_containers/plugin.py
@@ -268,7 +268,7 @@ class ContainerEnvironment(EnvironmentInterface):
                 )
 
                 for artifact in local_artifact_dir.iterdir():
-                    artifact.replace(output_dir / artifact.name)
+                    shutil.move(artifact, output_dir / artifact.name)
             finally:
                 self.platform.run_command(
                     ['docker', 'stop', '--time', '0', self.builder_container_name], capture_output=True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,8 +103,8 @@ def default_python_version():
 
 
 @pytest.fixture(scope='session')
-def default_container_name(project_name):
-    return f'{project_name}_default'
+def default_container_name(project_name, default_python_version):
+    return f'{project_name}_default_python_{default_python_version}-slim_{os.getuid()}_{os.getgid()}'
 
 
 @pytest.fixture(scope='session')


### PR DESCRIPTION
# Run containers as the uid and gid of the user

There are two main reasons why we don't want to run as root inside the containers:

1. Running as root is bad practice and a security risk.
2. All files generated within the container (eg `__pycache__` and artifacts etc) are owned by the root user on the host, resulting in file ownership issues in the user's project directory.

My approach in this commit is to create Docker images that execute commands as the user running `hatch`.

In the vast majority of cases the user will be the only user on the system, but on shared machines we need to handle this gracefully. My solution is to treat every UID:GID combination as a unique identity and create a Docker image with a name that looks like this:

    python_3.11-alpine_1000_1000

In this case the UID and GID are both `1000`. Every time this particular user executes `hatch run` for this environment, `hatch-containers` will select this container (if it already exists).

This fixes:

- https://github.com/ofek/hatch-containers/issues/12
- https://github.com/ofek/hatch-containers/issues/13

# Use shtuil.move() instead of os.replace()

Fixes:

- https://github.com/ofek/hatch-containers/issues/14

# Discussion

Let me know what you think about my approach. Happy to rework the PR as needed.

What operating systems does `hatch-containers` currently support? If it's not just Unix then I've got some rethinking to do as I've paid no attention to Windows (and have no idea how Docker and file permissions work there).